### PR TITLE
Updated version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,11 @@
         }
     ],
     "require": {
-        "laravel/framework": "4.*"
+        "laravel/framework": "~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit":   "4.2.2",
-        "mockery/mockery":   "0.9.1"
+        "phpunit/phpunit":   "~4.2.2",
+        "mockery/mockery":   "~0.9.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Instead of requiring phpunit 4.2.2, let's ask for 4.2.2, or any newer 4.2.x version.
- Instead of requiring mockery 0.9.1, let's ask for 0.9.1, or any newer 0.9.x version.
