### PR TITLE
fix template for requests page

### DIFF
--- a/src/Modules/Request/default.blade.php
+++ b/src/Modules/Request/default.blade.php
@@ -78,7 +78,7 @@
         @foreach($server as $key => $value)
         <tr>
             <td>{{ $key }}</td>
-            <td class="code">{{ str_limit(print_r($value)) }}</td>
+            <td class="code">{{ str_limit(print_r($value, true)) }}</td>
         </tr>
         @endforeach
     </tbody>

--- a/src/Modules/Request/default.blade.php
+++ b/src/Modules/Request/default.blade.php
@@ -78,7 +78,7 @@
         @foreach($server as $key => $value)
         <tr>
             <td>{{ $key }}</td>
-            <td class="code">{{ str_limit($value) }}</td>
+            <td class="code">{{ str_limit(print_r($value)) }}</td>
         </tr>
         @endforeach
     </tbody>


### PR DESCRIPTION
str_limit supposed to receive string, no array. But argv is array (at least, in some web server configs).
print_r($value, true) works fine.
